### PR TITLE
Use ffmpeg with rawvideo demuxer

### DIFF
--- a/com.inochi2d.inochi-creator.metainfo.xml
+++ b/com.inochi2d.inochi-creator.metainfo.xml
@@ -19,69 +19,71 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="0.8.0" date="2023-05-02"/>
-    <release version="v0.7.4.1" date="2022-10-10" type="stable">
+    <release version="0.8.0" date="2023-05-02">
+      <url>https://github.com/Inochi2D/inochi-creator/releases/tag/v0.8.0</url>
+    </release>
+    <release version="0.7.4.1" date="2022-10-10">
       <url>https://github.com/Inochi2D/inochi-creator/releases/tag/v0.7.4.1</url>
-          <description>
-            <p>Changelog</p>
-            <ul>
-                <li>Added support for xdg-desktop-portal on Linux</li>
-                <li>Added link buttons</li>
-                <li>Added welcome screen</li>
-                <li>Added banner illustration by 七乃ななせ</li>
-                <li>Added shadowed text widget</li>
-                <li>Added a new Inochi Creator icon</li>
-                <li>Added new fancy texture slot</li>
-                <li>Added support for editing post processing textures</li>
-                <li>Added ability to convert albedo textures to emmission textures</li>
-                <li>Added right click menu in viewport for part selection</li>
-                <li>Added model export dialog</li>
-                <li>Added new Camera node</li>
-                <li>Added image export</li>
-                <li>Added border scroll to nodes list when dragging nodes around</li>
-                <li>Added parameter groups with coloration support</li>
-                <li>Added internal support for custom toolbars</li>
-                <li>Added experimental timeline in InExperimental</li>
-                <li>Added new issue templates for bug reporting and feature requests</li>
-                <li>Added links in the help menu for bug reporting and feature requests</li>
-                <li>Updated Japanese translation</li>
-                <li>Updated Chinese translations</li>
-                <li>Updated Danish translation</li>
-                <li>Updated italian translation</li>
-                <li>Updated shortcut handling</li>
-                <li>Updated UI scaling implementation (still work in progress)</li>
-                <li>Updated UI settings window with a new design</li>
-                <li>Updated parameter axes with a new design</li>
-                <li>Updated look of categories in the inspector</li>
-                <li>Updated look and functionality of the viewport</li>
-                <li>Updated the look and functionality of mesh editing</li>
-                <li>Updated light theme</li>
-                <li>Changed packaging format on Linux to Flatpak</li>
-                <li>Changed how parameters are displayed when editing</li>
-                <li>Changed minimum window size to 960x720</li>
-                <li>Changed Gizmo settings to be in a submenu</li>
-                <li>Fixed multiple textures conflicting on PSD merge</li>
-                <li>Fixed rendering of armed parameters</li>
-                <li>Fixed various imgui assert crashes</li>
-                <li>Fixed path corruption in previous projects list</li>
-                <li>Fixed physics being enabled when editing deformation</li>
-                <li>Fixed null terminator in string input</li>
-                <li>Fixed undo system for parameter editing</li>
-                <li>Fixed undo system for moving node around</li>
-                <li>Fixed language selection not showing language name in their native language</li>
-                <li>Fixed ordering of language selection</li>
-                <li>Fixed parameters not getting disarmed on project load</li>
-                <li>Fixed Wayland detection code</li>
-                <li>Fixed accuracy camera auto focus functionality</li>
-                <li>Fixed some windows not running their quit functionality when closed</li>
-                <li>Fixed display of gravity units in Puppet inspector</li>
-                <li>Fixed vertex offset during merge being applied wrong</li>
-                <li>Fixed center node/Viewport accidentally being a dockable node</li>
-                <li>Fixed icon on Linux with X11 being wrong</li>
-                <li>Removed LTO compilation</li>
-                <li>Removed Test Mode temporarily</li>
-            </ul>
-          </description>
+      <description>
+        <p>Changelog</p>
+        <ul>
+            <li>Added support for xdg-desktop-portal on Linux</li>
+            <li>Added link buttons</li>
+            <li>Added welcome screen</li>
+            <li>Added banner illustration by 七乃ななせ</li>
+            <li>Added shadowed text widget</li>
+            <li>Added a new Inochi Creator icon</li>
+            <li>Added new fancy texture slot</li>
+            <li>Added support for editing post processing textures</li>
+            <li>Added ability to convert albedo textures to emmission textures</li>
+            <li>Added right click menu in viewport for part selection</li>
+            <li>Added model export dialog</li>
+            <li>Added new Camera node</li>
+            <li>Added image export</li>
+            <li>Added border scroll to nodes list when dragging nodes around</li>
+            <li>Added parameter groups with coloration support</li>
+            <li>Added internal support for custom toolbars</li>
+            <li>Added experimental timeline in InExperimental</li>
+            <li>Added new issue templates for bug reporting and feature requests</li>
+            <li>Added links in the help menu for bug reporting and feature requests</li>
+            <li>Updated Japanese translation</li>
+            <li>Updated Chinese translations</li>
+            <li>Updated Danish translation</li>
+            <li>Updated italian translation</li>
+            <li>Updated shortcut handling</li>
+            <li>Updated UI scaling implementation (still work in progress)</li>
+            <li>Updated UI settings window with a new design</li>
+            <li>Updated parameter axes with a new design</li>
+            <li>Updated look of categories in the inspector</li>
+            <li>Updated look and functionality of the viewport</li>
+            <li>Updated the look and functionality of mesh editing</li>
+            <li>Updated light theme</li>
+            <li>Changed packaging format on Linux to Flatpak</li>
+            <li>Changed how parameters are displayed when editing</li>
+            <li>Changed minimum window size to 960x720</li>
+            <li>Changed Gizmo settings to be in a submenu</li>
+            <li>Fixed multiple textures conflicting on PSD merge</li>
+            <li>Fixed rendering of armed parameters</li>
+            <li>Fixed various imgui assert crashes</li>
+            <li>Fixed path corruption in previous projects list</li>
+            <li>Fixed physics being enabled when editing deformation</li>
+            <li>Fixed null terminator in string input</li>
+            <li>Fixed undo system for parameter editing</li>
+            <li>Fixed undo system for moving node around</li>
+            <li>Fixed language selection not showing language name in their native language</li>
+            <li>Fixed ordering of language selection</li>
+            <li>Fixed parameters not getting disarmed on project load</li>
+            <li>Fixed Wayland detection code</li>
+            <li>Fixed accuracy camera auto focus functionality</li>
+            <li>Fixed some windows not running their quit functionality when closed</li>
+            <li>Fixed display of gravity units in Puppet inspector</li>
+            <li>Fixed vertex offset during merge being applied wrong</li>
+            <li>Fixed center node/Viewport accidentally being a dockable node</li>
+            <li>Fixed icon on Linux with X11 being wrong</li>
+            <li>Removed LTO compilation</li>
+            <li>Removed Test Mode temporarily</li>
+        </ul>
+      </description>
     </release>
   </releases>
   <url type="homepage">https://lunafoxgirlvt.itch.io/inochi-creator</url>

--- a/com.inochi2d.inochi-creator.yml
+++ b/com.inochi2d.inochi-creator.yml
@@ -4,6 +4,7 @@ runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.ldc
+  - org.freedesktop.Sdk.Extension.llvm14
 command: inochi-creator
 finish-args:
   - --device=all     #OpenGL rendering, webcams (may be required? not sure)
@@ -12,18 +13,21 @@ finish-args:
   - --socket=wayland
   - --filesystem=host     #This is a dev tool, it should probably have as much access to the host as it can. Also needs it for "Recent Files"
 
-
-#This extension will be needed in some newer releases, as of https://github.com/Inochi2D/inochi-creator/commit/5d67cded1273aced9033d327a8eb29c6f078a3c0
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    version: '22.08'
-    autodownload: true
-    autodelete: false
+## freedesktop ffmpeg extension doesn't provide rawvideo demuxer
+##This extension will be needed in some newer releases, as of https://github.com/Inochi2D/inochi-creator/commit/5d67cded1273aced9033d327a8eb29c6f078a3c0
+#add-extensions:
+#  org.freedesktop.Platform.ffmpeg-full:
+#    version: '22.08'
+#    autodownload: true
+#    autodelete: false
 
 
 modules:
 
   - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
+
+  # Add ffmpeg to support animation recording
+  - modules/ffmpeg.yml
 
   # --- Inochi Creator ---
   - name: Inochi-Creator

--- a/modules/ffmpeg.yml
+++ b/modules/ffmpeg.yml
@@ -1,0 +1,107 @@
+name: ffmpeg
+
+# Add required libs to this file
+#modules:
+#  ffmpeg-libs.yml
+
+config-opts:
+  - --disable-stripping
+  - --disable-doc
+  - --disable-static
+  - --enable-shared
+  - --disable-everything
+  - --enable-ffplay
+  - --enable-ffprobe
+  - --enable-gnutls
+  - --enable-libaom
+  - --enable-libdav1d
+  - --enable-libfdk-aac
+  - --enable-libmp3lame
+  - --enable-libfontconfig
+  - --enable-libfreetype
+  - --enable-libopus
+  - --enable-libpulse
+  - --enable-libspeex
+  - --enable-libtheora
+  - --enable-libvorbis
+  - --enable-libvpx
+  - --enable-libwebp
+  - --enable-openal
+  - --enable-opengl
+  - --enable-sdl2
+  - --enable-vulkan
+  - --enable-zlib
+  - --enable-libv4l2
+  - --enable-libxcb
+  - --enable-vdpau
+  - --enable-vaapi
+  - --enable-pthreads
+  - --enable-libopenh264
+  - >-
+    --enable-hwaccel=
+    vp8_vaapi,mjpeg_vaapi,h263_vaapi,h264_vaapi,h264_vdpau,hevc_vaapi,
+    hevc_vdpau,mpeg4_vaapi,mpeg4_vdpau
+  - >-
+    --enable-parser=
+    aac,ac3,flac,mjpeg,mpegaudio,mpeg4video,opus,vp3,vp8,vp9,vorbis,hevc,
+    h263,h264,dca
+  - >-
+    --enable-muxer=
+    ac3,ass,flac,g722,gif,matroska,mp3,mpegvideo,rtp,ogg,opus,
+    pcm_s16be,pcm_s16le,wav,webm,asf,avi,h263,h264,hevc,mp4,rawvideo
+  - >-
+    --enable-demuxer=
+    aac,ac3,ass,flac,g722,gif,image_jpeg_pipe,image_png_pipe,
+    image_webp_pipe,matroska,mjpeg,mov,mp3,mpegvideo,ogg,pcm_mulaw,rawvideo,
+    pcm_alaw,pcm_s16be,pcm_s16le,rtp,wav,ape,asf,avi,h263,h264,hevc,m4v,
+    mjpeg_2000,mp4,wav,xwma
+  - >-
+    --enable-filter=
+    atempo,crop,scale,overlay,amix,amerge,aresample,format,aformat,fps,
+    transpose,pad
+  - >-
+    --enable-indev=
+    v4l2,xcbgrab
+  - >-
+    --enable-protocol=
+    crypto,file,pipe,rtp,srtp,rtsp,tcp,udp,unix,fd
+  # Audio codecs
+  - >-
+    --enable-encoder=
+    ac3,alac,flac,libfdk_aac,g723_1,mp2,libmp3lame,libopus,libspeex,
+    pcm_alaw,pcm_mulaw,pcm_f32le,pcm_s16be,pcm_s24be,pcm_s16le,
+    pcm_s24le,pcm_s32le,pcm_u8,tta,libvorbis,wavpack,wmav1,wmav2
+  - >-
+    --enable-decoder=
+    adpcm_g722,alac,flac,g723_1,g729,libfdk_aac,libopus,libspeex,
+    mp2,mp3,m4a,pcm_alaw,pcm_mulaw,pcm_f16le,pcm_f24le,pcm_f32be,
+    pcm_f32le,pcm_f64be,pcm_f64le,pcm_s16be,pcm_s16be_planar,pcm_s24be,
+    pcm_s16le,pcm_s16le_planar,pcm_s24le,pcm_s24le_planar,pcm_s32le,
+    pcm_s32le_planar,pcm_s64be,pcm_s64le,pcm_s8,pcm_s8_planar,
+    pcm_u8,pcm_u24be,pcm_u24le,pcm_u32be,pcm_u32le,tta,vorbis,wavpack,
+    ape,dca,eac3,mlp,tak,truehd,wmav1,wmav2,wmapro
+
+  # Video codecs
+  - >-
+    --enable-encoder=
+    ass,ffv1,libaom_av1,libvpx_vp8,libvpx_vp9,mjpeg_vaapi,rawvideo,
+    theora,vp8_vaapi,libopenh264,h263,h263p,h264,ljpeg,mpeg4,wmv1,wmv2
+  - >-
+    --enable-decoder=
+    ass,ffv1,mjpeg,mjpegb,libaom_av1,libdav1d,libvpx_vp8,libvpx_vp9,
+    rawvideo,theora,vp8,vp9,libopenh264,cinepak,flv,hevc,h263,h264,
+    indeo2,indeo3,indeo4,indeo5,jpeg2000,mpeg2video,mpeg4,msmpeg4,
+    msmpeg4v1,msmpeg4v2,msmpeg4v3,vp6,vp6a,vp6f,wmv1,wmv2,wmv3,wmv3image
+  # Image codecs
+  - >-
+    --enable-encoder=
+    bmp,gif,jpegls,png,tiff,webp
+  - >-
+    --enable-decoder=
+    bmp,gif,jpegls,png,tiff,webp
+cleanup:
+  - /share/ffmpeg/examples
+sources:
+  - type: archive
+    url: https://ffmpeg.org/releases/ffmpeg-6.0.tar.xz
+    sha256: 57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082

--- a/modules/ffmpeg.yml
+++ b/modules/ffmpeg.yml
@@ -47,14 +47,14 @@ config-opts:
     h263,h264,dca
   - >-
     --enable-muxer=
-    ac3,ass,flac,g722,gif,matroska,mp3,mpegvideo,rtp,ogg,opus,
-    pcm_s16be,pcm_s16le,wav,webm,asf,avi,h263,h264,hevc,mp4,rawvideo
+    ac3,ass,flac,g722,gif,matroska,mp3,mpegvideo,rtp,ogg,opus,pcm_s16be,
+    pcm_s16le,wav,webm,asf,avi,h263,h264,hevc,mp4,rawvideo,apng,avif,image2
   - >-
     --enable-demuxer=
     aac,ac3,ass,flac,g722,gif,image_jpeg_pipe,image_png_pipe,
     image_webp_pipe,matroska,mjpeg,mov,mp3,mpegvideo,ogg,pcm_mulaw,rawvideo,
     pcm_alaw,pcm_s16be,pcm_s16le,rtp,wav,ape,asf,avi,h263,h264,hevc,m4v,
-    mjpeg_2000,mp4,wav,xwma
+    mjpeg_2000,mp4,wav,xwma,apng
   - >-
     --enable-filter=
     atempo,crop,scale,overlay,amix,amerge,aresample,format,aformat,fps,
@@ -85,13 +85,15 @@ config-opts:
   - >-
     --enable-encoder=
     ass,ffv1,libaom_av1,libvpx_vp8,libvpx_vp9,mjpeg_vaapi,rawvideo,
-    theora,vp8_vaapi,libopenh264,h263,h263p,h264,ljpeg,mpeg4,wmv1,wmv2
+    theora,vp8_vaapi,libopenh264,h263,h263p,h264,ljpeg,mpeg4,wmv1,wmv2,
+    apng
   - >-
     --enable-decoder=
     ass,ffv1,mjpeg,mjpegb,libaom_av1,libdav1d,libvpx_vp8,libvpx_vp9,
     rawvideo,theora,vp8,vp9,libopenh264,cinepak,flv,hevc,h263,h264,
     indeo2,indeo3,indeo4,indeo5,jpeg2000,mpeg2video,mpeg4,msmpeg4,
-    msmpeg4v1,msmpeg4v2,msmpeg4v3,vp6,vp6a,vp6f,wmv1,wmv2,wmv3,wmv3image
+    msmpeg4v1,msmpeg4v2,msmpeg4v3,vp6,vp6a,vp6f,wmv1,wmv2,wmv3,
+    wmv3image,apng
   # Image codecs
   - >-
     --enable-encoder=


### PR DESCRIPTION
`org.freedesktop.Platform.ffmpeg-full` doesn't come with the `rawvideo` demuxer, which is needed to export animations.

This is already fixed in the 23.08beta3 version that doesn't restrict demuxers from it's build system, so this patch should get reverted when we have a new stable release.